### PR TITLE
Fixed ReadMe Encoder/Decoder Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ model = XTransformer(
     dec_num_tokens = 256,
     dec_depth = 6,
     dec_heads = 8,
-    dec_max_seq_len = 1024
+    dec_max_seq_len = 1024,
+    enc_num_memory_tokens = 0
 )
 
 src = torch.randint(0, 256, (1, 1024))


### PR DESCRIPTION
Encoder/Decoder Example is not working. The Encoder requires a value for `enc_num_memory_tokens`.

This should fix it. 