### PR TITLE
bug fixes for Rezero and GEGLU

### DIFF
--- a/x_transformers/x_transformers.py
+++ b/x_transformers/x_transformers.py
@@ -142,7 +142,8 @@ class Scale(nn.Module):
         self.fn = fn
 
     def forward(self, x, **kwargs):
-        return self.fn(x, **kwargs) * self.value
+        out, inter = self.fn(x, **kwargs)
+        return out * self.value, inter
 
 class Rezero(nn.Module):
     def __init__(self, fn):
@@ -151,7 +152,8 @@ class Rezero(nn.Module):
         self.g = nn.Parameter(torch.zeros(1))
 
     def forward(self, x, **kwargs):
-        return self.fn(x, **kwargs) * self.g
+        out, inter = self.fn(x, **kwargs)
+        return out * self.g, inter
 
 class ScaleNorm(nn.Module):
     def __init__(self, dim, eps = 1e-5):
@@ -180,7 +182,7 @@ class GEGLU(nn.Module):
 
     def forward(self, x):
         x, gate = self.proj(x).chunk(2, dim = -1)
-        return x * F.gelu(x)
+        return gate * F.gelu(x)
 
 class FeedForward(nn.Module):
     def __init__(self, dim, dim_out = None, mult = 4, glu = False, dropout = 0.):


### PR DESCRIPTION
1. Rezero after this change now works without exception being raised (raised in the old version).
2. According to Eq.6 from (https://arxiv.org/pdf/2002.05202.pdf), GEGLU should be implemented with `gate * F.gelu(x)`?