### PR TITLE
bug fix for _relative_position_bucket

### DIFF
--- a/x_transformers/x_transformers.py
+++ b/x_transformers/x_transformers.py
@@ -115,7 +115,7 @@ class RelativePositionBias(nn.Module):
     def _relative_position_bucket(relative_position, causal = True, num_buckets = 32, max_distance = 128):
         ret = 0
         n = -relative_position
-        if causal:
+        if not causal:
             num_buckets //= 2
             ret += (n < 0).long() * num_buckets
             n = torch.abs(n)


### PR DESCRIPTION
This bug is fixed based on a similar implementation from huggingface's transformers: (https://github.com/huggingface/transformers/blob/d944966b19a4d6860bddc7cdc1ba928ca8a0da91/src/transformers/models/t5/modeling_t5.py#L363)