### PR TITLE
Fix potential dropped mask in AutoregressiveWrapper

### DIFF
--- a/x_transformers/autoregressive_wrapper.py
+++ b/x_transformers/autoregressive_wrapper.py
@@ -89,17 +89,15 @@ class AutoregressiveWrapper(nn.Module):
         return out
 
     def forward(self, x, **kwargs):
-        pad = partial(pad_sequence, batch_first = True, padding_value = self.pad_value)
-
         xi = x[:, :-1]
         xo = x[:, 1:]
 
         # help auto-solve a frequent area of confusion around input masks in auto-regressive
         # if user supplies a mask that is only off by one from the source sequence, resolve it for them
-        mask = kwargs.pop('mask', None)
+        mask = kwargs.get('mask', None)
         if mask is not None and mask.shape[1] == x.shape[1]:
             mask = mask[:, :-1]
-            kwargs.update(mask = mask)
+            kwargs['mask'] = mask
 
         out = self.net(xi, **kwargs)
         loss = F.cross_entropy(out.transpose(1, 2), xo, ignore_index = self.ignore_index)


### PR DESCRIPTION
`AutoregressiveWrapper.forward` has some logic for replacing a mask. But if `mask` was already the right shape, it gets dropped from `kwargs`.

This PR is an attempt to guess what was intended. I haven't yet convinced myself that the "auto-solve" logic is always what is desired; "explicit is better than implicit" would suggest removing it in favor of an assert with a helpful message (or an exception).

I also removed `pad`, which seemed to be unused (why not use it?).

This is a drive-by PR; I have not tested this code.