### PR TITLE
added support to pass kwargs to decoder generate method

### DIFF
--- a/x_transformers/x_transformers.py
+++ b/x_transformers/x_transformers.py
@@ -876,9 +876,9 @@ class XTransformer(nn.Module):
         self.decoder = AutoregressiveWrapper(self.decoder)
 
     @torch.no_grad()
-    def generate(self, seq_in, seq_out_start, seq_len, src_mask = None):
+    def generate(self, seq_in, seq_out_start, seq_len, src_mask = None, **kwargs):
         encodings = self.encoder(seq_in, return_embeddings = True, mask = src_mask)
-        return self.decoder.generate(seq_out_start, seq_len, context = encodings, context_mask = src_mask)
+        return self.decoder.generate(seq_out_start, seq_len, context = encodings, context_mask = src_mask, **kwargs)
 
     def forward(self, src, tgt, src_mask = None, tgt_mask = None):
         enc = self.encoder(src, mask = src_mask, return_embeddings = True)


### PR DESCRIPTION
currently one has to call the `generate` method on decoder directly to change its arguments. This change enable passing  arguments on main model's `generate` method itself.