### PR TITLE
Fix talking_heads parameter name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ model = TransformerWrapper(
         dim = 512,
         depth = 6,
         heads = 8,
-        attn_talking_heads = True  # turn on information exchange between attention heads
+        talking_heads = True  # turn on information exchange between attention heads
     )
 )
 ```


### PR DESCRIPTION
seems to be called talking_heads ( https://github.com/lucidrains/x-transformers/blob/a11b178573d2941c98a2c6d5b3a15fd9c97d4884/x_transformers/x_transformers.py#L285 ) if I'm not mistaken