### PR TITLE
eliminate inplace operations

### DIFF
--- a/x_transformers/x_transformers.py
+++ b/x_transformers/x_transformers.py
@@ -699,7 +699,7 @@ class ViTransformerWrapper(nn.Module):
 
         cls_tokens = repeat(self.cls_token, '() n d -> b n d', b = b)
         x = torch.cat((cls_tokens, x), dim=1)
-        x += self.pos_embedding[:, :(n + 1)]
+        x = x + self.pos_embedding[:, :(n + 1)]
         x = self.dropout(x)
 
         x = self.attn_layers(x)
@@ -771,7 +771,7 @@ class TransformerWrapper(nn.Module):
     ):
         b, n, device, num_mem = *x.shape, x.device, self.num_memory_tokens
         x = self.token_emb(x)
-        x += self.pos_emb(x)
+        x = x + self.pos_emb(x)
         x = self.emb_dropout(x)
 
         x = self.project_emb(x)
@@ -844,7 +844,7 @@ class ContinuousTransformerWrapper(nn.Module):
         b, n, _, device = *x.shape, x.device
 
         x = self.project_in(x)
-        x += self.pos_emb(x)
+        x = x + self.pos_emb(x)
         x = self.emb_dropout(x)
 
         x, intermediates = self.attn_layers(x, mask = mask, mems = mems, return_hiddens = True, **kwargs)


### PR DESCRIPTION
Hi!

I experienced some problems during backward pass when tried to stack transformers on top of LSTM if there were inplace operations in transformers. So I decided to replace them with not inplace versions. It helped in my case, maybe worth including in the main repo.

```python
import torch
from torch import nn
from x_transformers import ContinuousTransformerWrapper, Encoder

class Model(nn.Module):
    def __init__(self, ):
        super().__init__()
        self.rnn = nn.LSTM(input_size=64, hidden_size=64, num_layers=1,
                           bidirectional=False, batch_first=True)
        self.transformer = ContinuousTransformerWrapper(
            max_seq_len=100,
            attn_layers=Encoder(
                dim=64,
                depth=1,
                heads=4
            )
        )

    def forward(self, x):
        x, _ = self.rnn(x)
        x = self.transformer(x)
        return x


m = Model().cuda()

x = torch.randn((10, 20, 64)).cuda()
loss = m(x).sum()
loss.backward()
```

```
RuntimeError: one of the variables needed for gradient computation has been modified by an inplace operation: [torch.cuda.FloatTensor [10, 20, 64]], which is output 0 of CudnnRnnBackward, is at version 1; expected version 0 instead. Hint: the backtrace further above shows the operation that failed to compute its gradient. The variable in question was changed in there or anywhere later. Good luck!
```