### PR TITLE
In AutoregressiveWrapper, if no attention mask is supplied, create a lower triangular one

### DIFF
--- a/x_transformers/autoregressive_wrapper.py
+++ b/x_transformers/autoregressive_wrapper.py
@@ -121,6 +121,18 @@ class AutoregressiveWrapper(nn.Module):
             mask = mask[:, :-1]
             kwargs['mask'] = mask
 
+        # if no attention mask is supplied, create a lower triangular one
+        attn_mask = kwargs.get('attn_mask', None)
+        if attn_mask is None:
+            attn_mask = torch.tril(
+                torch.full(
+                    size=(x.shape[0], 1, x.shape[1]-1, x.shape[1]-1),
+                    fill_value=True,
+                    device=x.device
+                )
+            )
+            kwargs['attn_mask'] = attn_mask
+
         out = self.net(xi, **kwargs)
         loss = F.cross_entropy(out.transpose(1, 2), xo, ignore_index = self.ignore_index)
         return loss


### PR DESCRIPTION
Hi @lucidrains 
Thank you for your amazing work with all of your repositories!
I don't know if this behavior fits the minimal philosophy of this implementation but usually when training in an autoregressive fashion the future tokens are masked to prevent the transformer to "see in the future".
I added a default lower triangular attention mask in the `AutoregressiveWrapper` forward logic to implement this idea.
I tested it in a decoder-only architecture like the one from the `enwik8` example and it works. 
Reading the code it should work in a encoder-decoder architecture with `cross_attend = True` too but i haven't tested it.