### PR TITLE
Arbitrary positions in absolute PE

### DIFF
--- a/x_transformers/x_transformers.py
+++ b/x_transformers/x_transformers.py
@@ -127,9 +127,10 @@ class AbsolutePositionalEmbedding(nn.Module):
         self.l2norm_embed = l2norm_embed
         self.emb = nn.Embedding(max_seq_len, dim)
 
-    def forward(self, x):
-        n = torch.arange(x.shape[1], device = x.device)
-        pos_emb = self.emb(n)
+    def forward(self, x, pos = None):
+        if not exists(pos):
+            pos = torch.arange(x.shape[1], device = x.device)
+        pos_emb = self.emb(pos)
         pos_emb = rearrange(pos_emb, 'n d -> () n d')
         pos_emb = pos_emb * self.scale
         return l2norm(pos_emb) if self.l2norm_embed else pos_emb
@@ -140,9 +141,11 @@ class FixedPositionalEmbedding(nn.Module):
         inv_freq = 1. / (10000 ** (torch.arange(0, dim, 2).float() / dim))
         self.register_buffer('inv_freq', inv_freq)
 
-    def forward(self, x, seq_dim = 1, offset = 0):
-        t = torch.arange(x.shape[seq_dim], device = x.device).type_as(self.inv_freq) + offset
-        sinusoid_inp = torch.einsum('i , j -> i j', t, self.inv_freq)
+    def forward(self, x, pos = None, seq_dim = 1, offset = 0):
+        if not exists(pos):
+            pos = torch.arange(x.shape[seq_dim], device = x.device)
+        pos = pos.type_as(self.inv_freq) + offset
+        sinusoid_inp = torch.einsum('i , j -> i j', pos, self.inv_freq)
         emb = torch.cat((sinusoid_inp.sin(), sinusoid_inp.cos()), dim=-1)
         return rearrange(emb, 'n d -> () n d')
 
@@ -1118,12 +1121,13 @@ class TransformerWrapper(nn.Module):
         return_mems = False,
         return_attn = False,
         mems = None,
+        pos = None,
         **kwargs
     ):
         b, n, device, num_mem = *x.shape, x.device, self.num_memory_tokens
         return_hiddens = return_mems | return_attn
 
-        x = self.token_emb(x) + self.pos_emb(x)
+        x = self.token_emb(x) + self.pos_emb(x, pos = pos)
         x = self.emb_dropout(x)
 
         x = self.project_emb(x)
@@ -1198,12 +1202,13 @@ class ContinuousTransformerWrapper(nn.Module):
         mask = None,
         return_attn = False,
         mems = None,
+        pos = None,
         **kwargs
     ):
         b, n, _, device = *x.shape, x.device
 
         x = self.project_in(x)
-        x = x + self.pos_emb(x)
+        x = x + self.pos_emb(x, pos = pos)
         x = self.emb_dropout(x)
 
         x, intermediates = self.attn_layers(x, mask = mask, mems = mems, return_hiddens = True, **kwargs)


### PR DESCRIPTION
This PR enables feeding an arbitrary position tensor to `AbsolutePositionalEmbedding` and `FixedPositionalEmbedding`, including:
- A different sequence of positions for each item in the batch
- Float (non-integer) positions in the case of `FixedPositionalEmbedding`