### PR TITLE
amount by which to shift should be less than or equal to input tensor dimension

### DIFF
--- a/x_transformers/x_transformers.py
+++ b/x_transformers/x_transformers.py
@@ -409,6 +409,8 @@ class GRUGating(nn.Module):
 def shift(t, amount, mask = None):
     if amount == 0:
         return t
+    else:
+        amount = min(amount, t.shape[1])
 
     if exists(mask):
         t = t.masked_fill(~mask[..., None], 0.)


### PR DESCRIPTION
In current shift implementation this will fail
```python
t = torch.rand((2,1,10))
shift(t, 2)
```
with following exception
```python
File /cluster/work/gurvinde/.env/lib/python3.9/site-packages/torch/nn/functional.py:4364, in _pad(input, pad, mode, value)
   4362 assert len(pad) // 2 <= input.dim(), "Padding length too large"
   4363 if mode == "constant":
-> 4364     return _VF.constant_pad_nd(input, pad, value)
   4365 else:
   4366     assert value == 0.0, 'Padding mode "{}"" doesn\'t take in value argument'.format(mode)

RuntimeError: start (0) + length (-1) exceeds dimension size (1).
```
This patch fixes the issue. 