### PR TITLE
Could not call torch.save on the model

### DIFF
--- a/x_transformers/attend.py
+++ b/x_transformers/attend.py
@@ -13,7 +13,7 @@ from einops import rearrange
 
 # constants
 
-Config = namedtuple('EfficientAttentionConfig', ['enable_flash', 'enable_math', 'enable_mem_efficient'])
+EfficientAttentionConfig = namedtuple('EfficientAttentionConfig', ['enable_flash', 'enable_math', 'enable_mem_efficient'])
 
 @dataclass
 class Intermediates:
@@ -81,7 +81,7 @@ class Attend(nn.Module):
 
         # determine efficient attention configs for cuda and cpu
 
-        self.cpu_config = Config(True, True, True)
+        self.cpu_config = EfficientAttentionConfig(True, True, True)
         self.cuda_config = None
 
         if not torch.cuda.is_available() or not flash:
@@ -91,10 +91,10 @@ class Attend(nn.Module):
 
         if device_properties.major == 8 and device_properties.minor == 0:
             print_once('A100 GPU detected, using flash attention if input tensor is on cuda')
-            self.cuda_config = Config(True, False, False)
+            self.cuda_config = EfficientAttentionConfig(True, False, False)
         else:
             print_once('Non-A100 GPU detected, using math or mem efficient attention if input tensor is on cuda')
-            self.cuda_config = Config(False, True, True)
+            self.cuda_config = EfficientAttentionConfig(False, True, True)
 
     def flash_attn(
         self,


### PR DESCRIPTION
When calling torch.save on the model, since implementing the fast attention, i got a pickling error:

```
----> 1 torch.save(x, 'test.pt')

File /usr/local/Caskroom/miniconda/base/envs/repo/lib/python3.8/site-packages/torch/serialization.py:441, in save(obj, f, pickle_module, pickle_protocol, _use_new_zipfile_serialization)
    439 if _use_new_zipfile_serialization:
    440     with _open_zipfile_writer(f) as opened_zipfile:
--> 441         _save(obj, opened_zipfile, pickle_module, pickle_protocol)
    442         return
    443 else:

File /usr/local/Caskroom/miniconda/base/envs/repo/lib/python3.8/site-packages/torch/serialization.py:653, in _save(obj, zip_file, pickle_module, pickle_protocol)
    651 pickler = pickle_module.Pickler(data_buf, protocol=pickle_protocol)
    652 pickler.persistent_id = persistent_id
--> 653 pickler.dump(obj)
    654 data_value = data_buf.getvalue()
    655 zip_file.write_record('data.pkl', data_value, len(data_value))

PicklingError: Can't pickle <class 'x_transformers.attend.EfficientAttentionConfig'>: attribute lookup EfficientAttentionConfig on x_transformers.attend failed
```

You can reproduce this with the following script
```python
from x_transformers import TransformerWrapper, Decoder
x = TransformerWrapper(num_tokens=10, max_seq_len=10, attn_layers=Decoder(dim=10, depth=1, heads=1))
torch.save('test.pt', x)
```