### PR TITLE
cascading transformer comment typo

### DIFF
--- a/x_transformers/attend.py
+++ b/x_transformers/attend.py
@@ -380,7 +380,7 @@ class CascadingHeads(nn.Module):
         attn_bias = to_single_heads(attn_bias, dim = 0) if exists(attn_bias) else ((None,) * heads)
         prev_attn = to_single_heads(prev_attn) if exists(prev_attn) else ((None,) * heads)
 
-        # now loop through each head, without output of previous head summed with the next head
+        # now loop through each head, adding the output of the previous head to the next head's query
         # thus cascading
 
         all_outs = []


### PR DESCRIPTION
Sorry if I am misunderstanding cascading head paper, in the paper ([pdf link](https://arxiv.org/pdf/2305.07027.pdf)), they are adding the previous head's attn output to next head's input `(X'ij = Xij + ~Xi(j-1)) eq -3.`  This head's input will be then mapped into k,q,v through their respective linear layers. 
But why do we add it only to query in this repo's implementation? Is it because it might break kv-cache, etc. Sorry, if this is too noob of a question, I am still learning. Thanks.
![image](https://github.com/lucidrains/x-transformers/assets/8834712/089194ed-9370-4e2d-8cbe-a41b76cde4e6)
