### PR TITLE
fix missed imports in continuous.py

### DIFF
--- a/x_transformers/continuous.py
+++ b/x_transformers/continuous.py
@@ -2,11 +2,14 @@ import torch
 from torch import nn
 import torch.nn.functional as F
 
+from einops import pack, repeat, unpack
+
 from x_transformers.x_transformers import (
     AttentionLayers,
     ScaledSinusoidalEmbedding,
     AbsolutePositionalEmbedding,
-    always
+    always,
+    pad_at_dim
 )
 
 # helper functions


### PR DESCRIPTION
hit these trying to use memory tokens with the continuous wrapper