### PR TITLE
Init bias=0 in to_logits

### DIFF
--- a/x_transformers/x_transformers.py
+++ b/x_transformers/x_transformers.py
@@ -1524,7 +1524,11 @@ class TransformerWrapper(nn.Module):
         self.init_()
 
         logits_dim = default(logits_dim, num_tokens)
-        self.to_logits = nn.Linear(dim, logits_dim) if not tie_embedding else lambda t: t @ self.token_emb.emb.weight.t()
+        if tie_embedding:
+            self.to_logits = lambda t: t @ self.token_emb.emb.weight.t()
+        else:
+            self.to_logits = nn.Linear(dim, logits_dim)
+            nn.init.constant_(self.to_logits.bias, 0.)
 
         # memory tokens (like [cls]) from Memory Transformers paper
 


### PR DESCRIPTION
This bias randomly skews the initial distribution, which does not have a productive purpose.

Tested minor improvement in PPL with this change, but improvement was not apples-to-apples. Might also be noise.