### PR TITLE
Update x_transformers.py

### DIFF
--- a/x_transformers/x_transformers.py
+++ b/x_transformers/x_transformers.py
@@ -1457,7 +1457,7 @@ class ViTransformerWrapper(nn.Module):
             LayerNorm(dim)
         )
 
-        LayerNorm(dim) if post_emb_norm else nn.Identity()
+        self.post_emb_norm = LayerNorm(dim) if post_emb_norm else nn.Identity()
         self.dropout = nn.Dropout(emb_dropout)
 
         self.attn_layers = attn_layers


### PR DESCRIPTION
ViTransformerWrapper was lacking self.post_emb_norm layer in line 1460, throwing an error when forwarding an input