### PR TITLE
Allow passing in a pre-existing TokenEmbedding into TransformerWrapper

### DIFF
--- a/x_transformers/x_transformers.py
+++ b/x_transformers/x_transformers.py
@@ -13,7 +13,7 @@ from torch.cuda.amp import autocast
 from functools import partial, wraps
 from collections import namedtuple
 from dataclasses import dataclass
-from typing import List, Dict, Tuple, Callable
+from typing import List, Dict, Tuple, Callable, Optional
 
 from einops import rearrange, repeat, reduce, pack, unpack
 from einops.layers.torch import Rearrange
@@ -1925,7 +1925,8 @@ class TransformerWrapper(Module):
         attn_z_loss_weight = 1e-4,
         average_pool_embed = False,
         use_cls_token = False,
-        squeeze_out_last_dim = False
+        squeeze_out_last_dim = False,
+        token_emb: Optional[TokenEmbedding] = None,
     ):
         super().__init__()
 
@@ -1939,7 +1940,10 @@ class TransformerWrapper(Module):
         self.shift_mem_down = shift_mem_down
 
         self.l2norm_embed = l2norm_embed
-        self.token_emb = TokenEmbedding(emb_dim, num_tokens, l2norm_embed = l2norm_embed)
+        if token_emb:
+            self.token_emb = token_emb
+        else:
+            self.token_emb = TokenEmbedding(emb_dim, num_tokens, l2norm_embed = l2norm_embed)
 
         no_abs_pos_emb = max_seq_len == 0 or not (use_abs_pos_emb and not attn_layers.disable_abs_pos_emb)
 


### PR DESCRIPTION
TransformerWrapper takes an optional keyword argument token_emb. If not specified or set to the default value None, a new TokenEmbedding is created exactly as before.
If a TokenEmbedding is specified, it is used as the token_emb.

This feature is useful for parameter sharing, allowing the use of a single shared embedding with multiple Transformers. I have a use case for this feature in modular multilingual machine translation.

Closes #266