### PR TITLE
Missing always definition in XVal

### DIFF
--- a/x_transformers/xval.py
+++ b/x_transformers/xval.py
@@ -18,7 +18,8 @@ from x_transformers.x_transformers import (
     AttentionLayers,
     TokenEmbedding,
     ScaledSinusoidalEmbedding,
-    AbsolutePositionalEmbedding
+    AbsolutePositionalEmbedding,
+    always
 )
 
 from x_transformers.autoregressive_wrapper import (


### PR DESCRIPTION
Fixes `NameError: name 'always' is not defined` when instantiating `XValTransformerWrapper`