### PR TITLE
Customizable Embedder and Logit Mapper

### DIFF
--- a/tests/test_x_transformers.py
+++ b/tests/test_x_transformers.py
@@ -1,5 +1,3 @@
-from contextlib import nullcontext
-
 import pytest
 import torch
 

--- a/tests/test_x_transformers.py
+++ b/tests/test_x_transformers.py
@@ -441,8 +441,7 @@ def test_embedder(embedder_type):
 
 
 @pytest.mark.parametrize("to_logits", ('linear', 'none', 'pointer'))
-@pytest.mark.parametrize('tie_embedding', (True, False))
-def test_to_logits(to_logits, tie_embedding: bool):
+def test_to_logits(to_logits):
     num_tokens = 20000
     dim = 128
     to_logits_kwargs = {}
@@ -463,22 +462,16 @@ def test_to_logits(to_logits, tie_embedding: bool):
         logit_mapper = PointerNetworkLogits(dim)
         to_logits_kwargs['input_embeddings'] = torch.randn(2, 20000, dim)
 
-    if to_logits not in ('linear', 'none') and tie_embedding:
-        exception_context = pytest.raises(AssertionError)
-    else:
-        exception_context = nullcontext()
-    with exception_context:
-        model = TransformerWrapper(
-            num_tokens = num_tokens,
-            max_seq_len = 1024,
-            attn_layers = Decoder(
-                dim = dim,
-                depth = 6,
-                heads = 8,
-            ),
-            to_logits = logit_mapper,
-            tie_embedding=tie_embedding,
-        )
+    model = TransformerWrapper(
+        num_tokens = num_tokens,
+        max_seq_len = 1024,
+        attn_layers = Decoder(
+            dim = dim,
+            depth = 6,
+            heads = 8,
+        ),
+        to_logits = logit_mapper,
+    )
 
     x = torch.randint(0, num_tokens, (2, 1024))
     output = model(x, to_logits_kwargs=to_logits_kwargs)

--- a/tests/test_x_transformers.py
+++ b/tests/test_x_transformers.py
@@ -1,3 +1,5 @@
+from contextlib import nullcontext
+
 import pytest
 import torch
 
@@ -6,7 +8,7 @@ from x_transformers.x_transformers import (
     TransformerWrapper,
     Encoder,
     Decoder,
-    AutoregressiveWrapper,
+    LinearNoBias,
 )
 
 from x_transformers.neo_mlp import (
@@ -394,3 +396,90 @@ def test_custom_alibi():
     pos = torch.tensor([[0, 1, 2, 4], [1, 3, 5, 7]])
 
     logits = model(x, pos = pos)
+
+
+@pytest.mark.parametrize('embedder_type', ('embedding', 'none', 'custom'))
+def test_embedder(embedder_type):
+    num_tokens = 20000
+    dim = 128
+    token_emb_kwargs = {}
+    if embedder_type == 'embedding':
+        embedder = torch.nn.Embedding(num_tokens, dim)
+    elif embedder_type == 'none':
+        embedder = None
+    else:
+        class CustomEmbedder(torch.nn.Module):
+            """
+            Made up embedder that sums two embeddings. Just to check if we can pass additional input to the embedder's
+            forward pass without breaking the model.
+            """
+            def __init__(self, num_tokens, dim):
+                super().__init__()
+                self.embed_x = torch.nn.Embedding(num_tokens, dim)
+                self.embed_y = torch.nn.Embedding(num_tokens, dim)
+            def forward(self, x, y):
+                return self.embed_x(x) + self.embed_y(y)
+            def init_(self):
+                pass
+        embedder = CustomEmbedder(num_tokens, dim)
+        token_emb_kwargs['y'] = torch.randint(0, num_tokens, (2, 1024))
+    model = TransformerWrapper(
+        num_tokens = num_tokens,
+        max_seq_len = 1024,
+        attn_layers = Decoder(
+            dim = dim,
+            depth = 6,
+            heads = 8,
+        ),
+        token_emb = embedder,
+    )
+
+    x = torch.randint(0, 20000, (2, 1024))
+
+    output = model(x, token_emb_kwargs=token_emb_kwargs)
+    assert output.shape == (2, 1024, 20000)
+
+
+@pytest.mark.parametrize("to_logits", ('linear', 'none', 'pointer'))
+@pytest.mark.parametrize('tie_embedding', (True, False))
+def test_to_logits(to_logits, tie_embedding: bool):
+    num_tokens = 20000
+    dim = 128
+    to_logits_kwargs = {}
+    if to_logits == 'linear':
+        logit_mapper = LinearNoBias(dim, num_tokens)
+    elif to_logits == 'none':
+        logit_mapper = None
+    else:
+        class PointerNetworkLogits(torch.nn.Module):
+            def __init__(self, dim):
+                super().__init__()
+                self.proj_to_pointers = torch.nn.Linear(dim, dim)
+            def forward(self, model_embeddings, input_embeddings):
+                pointers = self.proj_to_pointers(model_embeddings)
+                logits = torch.matmul(pointers, input_embeddings.permute(0, 2, 1))
+                return logits
+
+        logit_mapper = PointerNetworkLogits(dim)
+        to_logits_kwargs['input_embeddings'] = torch.randn(2, 20000, dim)
+
+    if to_logits not in ('linear', 'none') and tie_embedding:
+        exception_context = pytest.raises(AssertionError)
+    else:
+        exception_context = nullcontext()
+    with exception_context:
+        model = TransformerWrapper(
+            num_tokens = num_tokens,
+            max_seq_len = 1024,
+            attn_layers = Decoder(
+                dim = dim,
+                depth = 6,
+                heads = 8,
+            ),
+            to_logits = logit_mapper,
+            tie_embedding=tie_embedding,
+        )
+
+    x = torch.randint(0, num_tokens, (2, 1024))
+    output = model(x, to_logits_kwargs=to_logits_kwargs)
+    assert output.shape == (2, 1024, 20000)

--- a/x_transformers/x_transformers.py
+++ b/x_transformers/x_transformers.py
@@ -233,7 +233,7 @@ class TokenEmbedding(Module):
         self.l2norm_embed = l2norm_embed
         self.emb = nn.Embedding(num_tokens, dim)
 
-    def forward(self, x):
+    def forward(self, x, **kwargs):
         token_emb = self.emb(x.long())
         return l2norm(token_emb) if self.l2norm_embed else token_emb
 

--- a/x_transformers/x_transformers.py
+++ b/x_transformers/x_transformers.py
@@ -244,6 +244,18 @@ class TokenEmbedding(Module):
         nn.init.kaiming_normal_(self.emb.weight)
 
 
+# logits mapper
+
+class LogitsMapper(Module):
+    def __init__(self, dim, num_tokens):
+        super().__init__()
+        self.num_tokens = num_tokens
+        self.to_logits = LinearNoBias(dim, num_tokens)
+
+    def forward(self, x, **kwargs):
+        return self.to_logits(x)
+
+
 # positional embeddings
 
 class AbsolutePositionalEmbedding(Module):
@@ -1712,7 +1724,8 @@ class AttentionLayers(Module):
         attn_bias = None,
         condition = None,
         in_attn_cond = None, # https://arxiv.org/abs/2105.04090
-        layers_execute_order: tuple[int, ...] | None = None
+        layers_execute_order: tuple[int, ...] | None = None,
+        **kwargs
     ):
         assert not (self.cross_attend ^ exists(context)), 'context must be passed in if cross_attend is set to True'
         assert not (exists(condition) ^ self.need_condition), 'condition needs to be passed in if using adaptive layernorm or vice versa'
@@ -2113,7 +2126,8 @@ class TransformerWrapper(Module):
         use_cls_token = False,
         num_cls_tokens = 1,
         squeeze_out_last_dim = False,
-        token_emb: TokenEmbedding | None = None,
+        token_emb: TokenEmbedding | Module | None = None,
+        to_logits: LogitsMapper | Module | None = None,
         mixture_of_softmax = False,
         mixture_of_softmax_k = 4,
         sigsoftmax_logits = False
@@ -2218,11 +2232,14 @@ class TransformerWrapper(Module):
         if return_only_embed:
             self.to_logits = None
         elif tie_embedding:
+            assert isinstance(token_emb, TokenEmbedding), \
+                'Tied embedding only supported with the `TokenEmbedding` embedder class'
             self.to_logits = lambda t: t @ self.token_emb.emb.weight.t()
         elif num_output_heads > 1:
+            assert not exists(to_logits), 'Cannot pass in `to_logits` when using multiple heads'
             self.to_logits = ModuleList([LinearNoBias(dim, logits_dim) for _ in range(num_output_heads)])
         else:
-            self.to_logits = LinearNoBias(dim, logits_dim)
+            self.to_logits = LogitsMapper(dim, logits_dim) if to_logits is None else to_logits
 
         # memory tokens (like [cls]) from Memory Transformers paper
 
@@ -2281,7 +2298,7 @@ class TransformerWrapper(Module):
 
         external_pos_emb = exists(pos) and pos.dtype != torch.long
         pos_emb = self.pos_emb(x, pos = pos, seq_start_pos = seq_start_pos) if not external_pos_emb else pos
-        x = self.token_emb(x) + pos_emb
+        x = self.token_emb(x, **kwargs) + pos_emb
 
         # add additional embeddings
 
@@ -2436,9 +2453,9 @@ class TransformerWrapper(Module):
 
         if not return_embeddings:
             if self.has_multiple_heads:
-                logits = tuple(fn(x) for fn in self.to_logits)
+                logits = tuple(fn(x, **kwargs) for fn in self.to_logits)
             else:
-                logits = self.to_logits(x)
+                logits = self.to_logits(x, **kwargs)
 
         # maybe sig softmax
 

--- a/x_transformers/x_transformers.py
+++ b/x_transformers/x_transformers.py
@@ -2426,6 +2426,7 @@ class TransformerWrapper(Module):
         cache: LayerIntermediates | None = None,
         token_emb_kwargs = dict(),
         to_logits_kwargs = dict(),
+        **kwargs,
     ):
         b, n, device, num_mems, has_memory_tokens, emb_frac_gradient, orig_mask = x.shape[0], x.shape[1], x.device, self.num_memory_tokens, self.num_memory_tokens > 0, self.emb_frac_gradient, mask
 
@@ -2534,7 +2535,7 @@ class TransformerWrapper(Module):
 
             # regular
 
-            attended, intermediates = self.attn_layers(x, mask = mask, mems = mems, mem_masks = mem_masks, cache = cache, return_hiddens = True, seq_start_pos = seq_start_pos)
+            attended, intermediates = self.attn_layers(x, mask = mask, mems = mems, mem_masks = mem_masks, cache = cache, return_hiddens = True, seq_start_pos = seq_start_pos, **kwargs)
 
         else:
             # recycling
@@ -2551,7 +2552,7 @@ class TransformerWrapper(Module):
                 with context():
                     maybe_recycled = self.recycled_proj(attended.detach()) if not first_step else 0.
 
-                    attended, intermediates = self.attn_layers(x + maybe_recycled, mask = mask, mems = mems, mem_masks = mem_masks, cache = cache, return_hiddens = True, seq_start_pos = seq_start_pos)
+                    attended, intermediates = self.attn_layers(x + maybe_recycled, mask = mask, mems = mems, mem_masks = mem_masks, cache = cache, return_hiddens = True, seq_start_pos = seq_start_pos, **kwargs)
 
         x = attended
 

--- a/x_transformers/x_transformers.py
+++ b/x_transformers/x_transformers.py
@@ -237,6 +237,13 @@ class TokenEmbedding(Module):
         token_emb = self.emb(x.long())
         return l2norm(token_emb) if self.l2norm_embed else token_emb
 
+    def init_(self):
+        if self.l2norm_embed:
+            nn.init.normal_(self.emb.weight, std=1e-5)
+            return
+        nn.init.kaiming_normal_(self.emb.weight)
+
+
 # positional embeddings
 
 class AbsolutePositionalEmbedding(Module):
@@ -2236,13 +2243,11 @@ class TransformerWrapper(Module):
         self.can_cache_kv_outside_max_seq_len = no_abs_pos_emb
 
     def init_(self):
+        if hasattr(self.token_emb, 'init_'):
+            self.token_emb.init_()
         if self.l2norm_embed:
-            nn.init.normal_(self.token_emb.emb.weight, std = 1e-5)
             if not isinstance(self.pos_emb, always):
                 nn.init.normal_(self.pos_emb.emb.weight, std = 1e-5)
-            return
-
-        nn.init.kaiming_normal_(self.token_emb.emb.weight)
 
     def forward(
         self,


### PR DESCRIPTION
Hi @lucidrains, I use x-transformers extensively and often run into the need to use custom embedder and logit mapper classes together with the `AutoregressiveWrapper` class, for e.g., to implement pointer networks (https://arxiv.org/abs/1506.03134). Currently this is not possible, so I work with the lower level `Decoder` class and implement the wrapper myself.

In this PR, I tried to enable support for this by slightly reorganizing the `TokenEmbedding` class, and adding a class called `LogitMapper` to be used as the `TransformerWrapper.to_logits` layer. The idea is that we can implement custom classes conforming to these interfaces and everything should work seamlessly. These classes accept kwargs in their forward method that allows us to pass additional tensors to them.

The unit tests all pass and I added some additional ones. I hope I didn't break anything! Let me know if you're ok to merge this change, or if you have better ways of achieving this behavior. Thank you.