### PR TITLE
Add `packaging` as requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ setup(
   install_requires=[
     'torch>=2.0',
     'einx>=0.3.0',
-    'einops>=0.8.0'
+    'einops>=0.8.0',
+    'packaging>=21.0',
   ],
   setup_requires=[
     'pytest-runner',


### PR DESCRIPTION
The pypa `packaging` module is a required import-time requirement (eg; [here](https://github.com/lucidrains/x-transformers/blob/abeedc8cb60180892f1c19b42548c9833abe4f5b/x_transformers/x_transformers.py#L6)) but isn't listed in setup.py. Adding it here for completeness.