### PR TITLE
Adding BatchNorm

### DIFF
--- a/x_transformers/x_transformers.py
+++ b/x_transformers/x_transformers.py
@@ -881,6 +881,14 @@ class DynamicTanh(Module):
         gamma = self.gamma + self.gamma_offset
         return (x * pre_tanh_scale).tanh() * gamma + self.beta
 
+class BatchNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.batchnorm = nn.BatchNorm1d(dim)
+
+    def forward(self, x):
+        return self.batchnorm(x.transpose(1, 2)).transpose(1, 2)
+        
 # residual and residual gates
 
 class Residual(Module):
@@ -1915,6 +1923,7 @@ class AttentionLayers(Module):
         use_adaptive_layernorm = False,
         use_adaptive_rmsnorm = False,
         use_adaptive_layerscale = False, # paired with use_adaptive_layernorm for ada-ln-zero from DiT paper
+        use_batchnorm = False,
         norm_add_unit_offset = True,
         dim_condition = None,
         adaptive_condition_mlp = False,
@@ -2060,7 +2069,7 @@ class AttentionLayers(Module):
 
         # determine norm
 
-        assert at_most_one_of(use_scalenorm, use_rmsnorm, use_dynamic_tanh, use_simple_rmsnorm, use_adaptive_layernorm, use_adaptive_rmsnorm), 'you can only use either scalenorm, rmsnorm, adaptive layernorm, adaptive rmsnorm, or simple rmsnorm'
+        assert at_most_one_of(use_scalenorm, use_rmsnorm, use_dynamic_tanh, use_simple_rmsnorm, use_adaptive_layernorm, use_adaptive_rmsnorm, use_batchnorm), 'you can only use either scalenorm, rmsnorm, adaptive layernorm, adaptive rmsnorm, simple rmsnorm, or use_batchnorm'
 
         norm_need_condition = False
         dim_condition = default(dim_condition, dim)
@@ -2084,6 +2093,8 @@ class AttentionLayers(Module):
         elif use_adaptive_rmsnorm:
             norm_need_condition = True
             norm_class = partial(AdaptiveRMSNorm, dim_condition = dim_condition * dim_condition_mult)
+        elif use_batchnorm:
+            norm_class = BatchNorm
         else:
             norm_class = LayerNorm
 


### PR DESCRIPTION
Cons:

- Yet another argument to AttentionLayers
- This is different from FFNBN in the [Leveraging Batch Normalization for Vision Transformers](https://openaccess.thecvf.com/content/ICCV2021W/NeurArch/papers/Yao_Leveraging_Batch_Normalization_for_Vision_Transformers_ICCVW_2021_paper.pdf) paper.

Pros:
- Time series transformer papers are empirically claiming better performance. [A Transformer-based Framework for Multivariate Time Series Representation Learning](https://arxiv.org/abs/2010.02803) made the original claim and [A Time Series is Worth 64 Words: Long-term Forecasting with Transformers](https://arxiv.org/abs/2211.14730) made it popular.