### PR TITLE
Fix typos in comments and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ loss = pali(
     prompt,
     output_text,
     mask = prompt_mask,
-    src_prepend_embeds = img_embeds             # will preprend image embeddings to encoder text embeddings before attention
+    src_prepend_embeds = img_embeds             # will prepend image embeddings to encoder text embeddings before attention
 )
 
 loss.backward()

--- a/x_transformers/continuous.py
+++ b/x_transformers/continuous.py
@@ -122,7 +122,7 @@ class ContinuousTransformerWrapper(Module):
         has_project_in = exists(dim_in) and (not use_identity_if_same_dim or dim_in != dim)
         self.project_in = default(project_in, lambda: nn.Linear(dim_in, dim, bias = False) if has_project_in else nn.Identity())
 
-        # output is multipled by 2 for outputting mean and log variance
+        # output is multiplied by 2 for outputting mean and log variance
 
         self.probabilistic = probabilistic
 
@@ -362,7 +362,7 @@ class ContinuousAutoregressiveWrapper(Module):
 
         mask = kwargs.pop('mask', None)
 
-        # pick a random range for each batch sample and aligh the sequence to the right for rollout loss
+        # pick a random range for each batch sample and align the sequence to the right for rollout loss
 
         valid_tokens_for_rollout = (lens - steps).clamp(min = 0)
         valid_sample = valid_tokens_for_rollout > 0


### PR DESCRIPTION
Fix three typos found in code comments and a README example:

- `multipled` -> `multiplied` in `x_transformers/continuous.py` (comment describing output projection)
- `aligh` -> `align` in `x_transformers/continuous.py` (comment describing rollout loss logic)
- `preprend` -> `prepend` in `README.md` (inline comment in PaLI usage example)