### PR TITLE
Avoid CUDA->CPU sync by removing tensor.bool check in attend.py

### DIFF
--- a/x_transformers/attend.py
+++ b/x_transformers/attend.py
@@ -467,7 +467,7 @@ class Attend(Module):
 
         # for a row that is entirely masked out, should zero out the output of that row token
 
-        if exists(row_is_entirely_masked) and row_is_entirely_masked.any():
+        if exists(row_is_entirely_masked):
             out = out.masked_fill(row_is_entirely_masked[..., None], 0.)
 
         return out, Intermediates()
@@ -643,7 +643,7 @@ class Attend(Module):
             post_softmax_attn = post_softmax_attn
         )
 
-        if exists(row_is_entirely_masked) and row_is_entirely_masked.any():
+        if exists(row_is_entirely_masked):
             out = out.masked_fill(row_is_entirely_masked[..., None], 0.)
 
         return out, intermediates


### PR DESCRIPTION
This change removes a device→host synchronization caused by evaluating a 0-dim CUDA tensor as a Python bool (via .any() / tensor.bool) in x_transformers/attend.py. Instead of checking row_is_entirely_masked.any() before calling masked_fill, we now simply check the tensor exists (which doesn't cause device->host sync) and always call masked_fill when present.

**What I changed**

In x_transformers/attend.py, removed the .any() boolean check in two places and always call masked_fill when row_is_entirely_masked exists:

- flash_attn branch
- forward branch

**Why**

Calling .any() and using the result as a Python truth value invokes tensor.bool which calls .item(), forcing a CUDA→CPU synchronization when the tensor lives on the GPU. This can **significantly degrade throughput for GPU workloads.**
masked_fill with an all-False boolean mask is a no-op (aside from a cheap kernel launch), so always calling masked_fill when the mask exists preserves correctness while avoiding the expensive sync.